### PR TITLE
#17 フォーカス移動改修

### DIFF
--- a/ios/GoogleService-Info.plist
+++ b/ios/GoogleService-Info.plist
@@ -3,23 +3,21 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>646270885310-g923nn1mfqic33j7u69ol4f4jkj3ra9c.apps.googleusercontent.com</string>
+	<string>1070077102168-jmn4vq8mpeel4ktcnqkmvpcofdj08p75.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.646270885310-g923nn1mfqic33j7u69ol4f4jkj3ra9c</string>
-	<key>ANDROID_CLIENT_ID</key>
-	<string>646270885310-ahhd2d5ut7uig4gv0fk05bdbgv424ajk.apps.googleusercontent.com</string>
+	<string>com.googleusercontent.apps.1070077102168-jmn4vq8mpeel4ktcnqkmvpcofdj08p75</string>
 	<key>API_KEY</key>
-	<string>AIzaSyAXRUAb1rTTT1TYd6aDv48OaEEmUxas434</string>
+	<string>AIzaSyBnJkaTRiT7PeN88nACwt2duMgjAdn9gcs</string>
 	<key>GCM_SENDER_ID</key>
-	<string>646270885310</string>
+	<string>1070077102168</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.toda.recipe</string>
+	<string>com.toda.recipe.dev</string>
 	<key>PROJECT_ID</key>
-	<string>recipe-app-74426</string>
+	<string>myrecipe-dev</string>
 	<key>STORAGE_BUCKET</key>
-	<string>recipe-app-74426.appspot.com</string>
+	<string>myrecipe-dev.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -31,6 +29,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:646270885310:ios:c2a77aa9224f49f7fa6def</string>
+	<string>1:1070077102168:ios:cd477236e5ab20cdb9e22d</string>
 </dict>
 </plist>

--- a/lib/components/widgets/edit_recipe_widget/edit_recipe_widget.dart
+++ b/lib/components/widgets/edit_recipe_widget/edit_recipe_widget.dart
@@ -23,268 +23,279 @@ class EditRecipeWidget extends ConsumerWidget {
     final imageFile = ref.watch(imageFileNotifierProvider);
     final imageFileNotifier = ref.watch(imageFileNotifierProvider.notifier);
 
-    return Container(
-      margin: const EdgeInsets.only(left: 20, right: 20).r,
-      width: double.infinity,
-      child: ListView(
-        children: [
-          SizedBox(height: 16.h),
-          TextField(
-            maxLength: 30,
-            maxLines: 2,
-            style: Theme.of(context).textTheme.headline5,
-            controller: TextEditingController(text: recipe.recipeName),
-            decoration: const InputDecoration.collapsed(hintText: 'レシピ名'),
-            onChanged: (value) {
-              recipe.recipeName = value;
-            },
-          ),
-          // 画像
-          SizedBox(height: 8.h),
-          GestureDetector(
-            child: SizedBox(
-              height: 250.h,
-              child: imageFile != null
-                  ? imageFile.path != ''
-                      ? ClipRRect(
-                          borderRadius: BorderRadius.circular(20),
-                          child: Image.file(imageFile),
-                        )
-                      : DecoratedBox(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(8),
-                            color: Theme.of(context).dividerColor,
-                          ),
-                          child: const Icon(Icons.add_photo_alternate_outlined),
-                        )
-                  : recipe.imageUrl != '' && recipe.imageUrl != null
-                      ? Image.network(
-                          recipe.imageUrl!,
-                          errorBuilder: (c, o, s) {
-                            return const Icon(
-                              Icons.error,
-                            );
-                          },
-                        )
-                      : DecoratedBox(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(8),
-                            color: Theme.of(context).dividerColor,
-                          ),
-                          child: const Icon(Icons.add_photo_alternate_outlined),
-                        ),
-            ),
-            onTap: () {
-              showAdaptiveActionSheet<BottomSheetAction>(
-                context: context,
-                title: const Text('画像の選択'),
-                androidBorderRadius: 30,
-                actions: <BottomSheetAction>[
-                  BottomSheetAction(
-                    title: const Text('アルバムから選択'),
-                    onPressed: () async {
-                      if (await Permission.photos.status.isGranted ||
-                          await Permission.photos.request().isGranted) {
-                        await imageFileNotifier.pickImage(ImageSource.gallery);
-                        Navigator.pop(context);
-                      } else {
-                        await showDialog<CupertinoAlertDialog>(
-                          context: context,
-                          builder: (context) {
-                            return CupertinoAlertDialog(
-                              title: const Text('写真へのアクセスが許可されていません'),
-                              content: const Text(
-                                '端末内の画像をレシピに保存するためには、アクセスの許可が必要です。',
-                              ),
-                              actions: <Widget>[
-                                CupertinoDialogAction(
-                                  child: const Text('キャンセル'),
-                                  onPressed: () => Navigator.pop(context),
-                                ),
-                                const CupertinoDialogAction(
-                                  onPressed: openAppSettings,
-                                  child: Text('設定へ'),
-                                ),
-                              ],
-                            );
-                          },
-                        );
-                      }
-                    },
-                  ),
-                  BottomSheetAction(
-                    title: const Text('カメラで撮影'),
-                    onPressed: () async {
-                      if (await Permission.camera.status.isGranted ||
-                          await Permission.camera.request().isGranted) {
-                        await imageFileNotifier.pickImage(ImageSource.camera);
-                        Navigator.pop(context);
-                      } else {
-                        await showDialog<CupertinoAlertDialog>(
-                          context: context,
-                          builder: (context) {
-                            return CupertinoAlertDialog(
-                              title: const Text('カメラへのアクセスが許可されていません'),
-                              content: const Text(
-                                'カメラで撮影した画像をレシピに保存するためには、アクセスの許可が必要です。',
-                              ),
-                              actions: <Widget>[
-                                CupertinoDialogAction(
-                                  child: const Text('キャンセル'),
-                                  onPressed: () => Navigator.pop(context),
-                                ),
-                                const CupertinoDialogAction(
-                                  onPressed: openAppSettings,
-                                  child: Text('設定へ'),
-                                ),
-                              ],
-                            );
-                          },
-                        );
-                      }
-                    },
-                  ),
-                ],
-                cancelAction: CancelAction(
-                  title: const Text('キャンセル'),
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                ),
-              );
-            },
-          ),
-          // 評価
-          SizedBox(height: 8.h),
-          Center(
-            child: RatingBar.builder(
-              initialRating: recipe.recipeGrade!,
-              minRating: 0.5,
-              allowHalfRating: true,
-              itemPadding: const EdgeInsets.symmetric(horizontal: 4).r,
-              itemBuilder: (context, _) => const Icon(
-                Icons.star_rounded,
-                color: Colors.amber,
-              ),
-              onRatingUpdate: (rating) {
-                recipe.recipeGrade = rating;
+    return GestureDetector(
+      onTap: () {
+        final currentScope = FocusScope.of(context);
+        if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+          FocusManager.instance.primaryFocus!.unfocus();
+        }
+      },
+      child: Container(
+        margin: const EdgeInsets.only(left: 20, right: 20).r,
+        width: double.infinity,
+        child: ListView(
+          children: [
+            SizedBox(height: 16.h),
+            TextField(
+              maxLength: 30,
+              maxLines: 2,
+              style: Theme.of(context).textTheme.headline5,
+              controller: TextEditingController(text: recipe.recipeName),
+              decoration: const InputDecoration.collapsed(hintText: 'レシピ名'),
+              onChanged: (value) {
+                recipe.recipeName = value;
               },
             ),
-          ),
-
-          // 材料
-          SizedBox(height: 8.h),
-          Column(
-            children: [
-              DefaultTextStyle(
-                style: Theme.of(context).textTheme.subtitle2!,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Row(
-                      children: [
-                        const Text('材料'),
-                        SizedBox(width: 8.w),
-                        SizedBox(
-                          width: 24.w,
-                          child: TextField(
-                            decoration: InputDecoration(
-                              contentPadding: const EdgeInsets.only(
-                                left: 2,
-                                top: 4,
-                                bottom: 4,
-                              ).r,
-                              isDense: true,
+            // 画像
+            SizedBox(height: 8.h),
+            GestureDetector(
+              child: SizedBox(
+                height: 250.h,
+                child: imageFile != null
+                    ? imageFile.path != ''
+                        ? ClipRRect(
+                            borderRadius: BorderRadius.circular(20),
+                            child: Image.file(imageFile),
+                          )
+                        : DecoratedBox(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(8),
+                              color: Theme.of(context).dividerColor,
                             ),
-                            controller: recipe.forHowManyPeople == null
-                                ? null
-                                : TextEditingController(
-                                    text: recipe.forHowManyPeople.toString(),
-                                  ),
-                            keyboardType: TextInputType.number,
-                            inputFormatters: <TextInputFormatter>[
-                              FilteringTextInputFormatter.digitsOnly,
-                              LengthLimitingTextInputFormatter(2)
-                            ],
-                            onChanged: (value) {
-                              if (int.tryParse(value) != null) {
-                                recipe.forHowManyPeople = int.parse(value);
-                              }
+                            child:
+                                const Icon(Icons.add_photo_alternate_outlined),
+                          )
+                    : recipe.imageUrl != '' && recipe.imageUrl != null
+                        ? Image.network(
+                            recipe.imageUrl!,
+                            errorBuilder: (c, o, s) {
+                              return const Icon(
+                                Icons.error,
+                              );
                             },
+                          )
+                        : DecoratedBox(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(8),
+                              color: Theme.of(context).dividerColor,
+                            ),
+                            child:
+                                const Icon(Icons.add_photo_alternate_outlined),
                           ),
-                        ),
-                        const Text('人分'),
-                      ],
-                    ),
-                    TextButton.icon(
-                      onPressed: () {
-                        Navigator.push<MaterialPageRoute<dynamic>>(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) =>
-                                const IntroductionEditIngredientPage(),
-                          ),
-                        );
+              ),
+              onTap: () {
+                showAdaptiveActionSheet<BottomSheetAction>(
+                  context: context,
+                  title: const Text('画像の選択'),
+                  androidBorderRadius: 30,
+                  actions: <BottomSheetAction>[
+                    BottomSheetAction(
+                      title: const Text('アルバムから選択'),
+                      onPressed: () async {
+                        if (await Permission.photos.status.isGranted ||
+                            await Permission.photos.request().isGranted) {
+                          await imageFileNotifier
+                              .pickImage(ImageSource.gallery);
+                          Navigator.pop(context);
+                        } else {
+                          await showDialog<CupertinoAlertDialog>(
+                            context: context,
+                            builder: (context) {
+                              return CupertinoAlertDialog(
+                                title: const Text('写真へのアクセスが許可されていません'),
+                                content: const Text(
+                                  '端末内の画像をレシピに保存するためには、アクセスの許可が必要です。',
+                                ),
+                                actions: <Widget>[
+                                  CupertinoDialogAction(
+                                    child: const Text('キャンセル'),
+                                    onPressed: () => Navigator.pop(context),
+                                  ),
+                                  const CupertinoDialogAction(
+                                    onPressed: openAppSettings,
+                                    child: Text('設定へ'),
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        }
                       },
-                      icon: Icon(
-                        Icons.help_outline_rounded,
-                        size: 20.sp,
-                        color: Theme.of(context).hintColor,
-                      ),
-                      label: Text(
-                        'ヘルプ',
-                        style: TextStyle(color: Theme.of(context).hintColor),
-                      ),
+                    ),
+                    BottomSheetAction(
+                      title: const Text('カメラで撮影'),
+                      onPressed: () async {
+                        if (await Permission.camera.status.isGranted ||
+                            await Permission.camera.request().isGranted) {
+                          await imageFileNotifier.pickImage(ImageSource.camera);
+                          Navigator.pop(context);
+                        } else {
+                          await showDialog<CupertinoAlertDialog>(
+                            context: context,
+                            builder: (context) {
+                              return CupertinoAlertDialog(
+                                title: const Text('カメラへのアクセスが許可されていません'),
+                                content: const Text(
+                                  'カメラで撮影した画像をレシピに保存するためには、アクセスの許可が必要です。',
+                                ),
+                                actions: <Widget>[
+                                  CupertinoDialogAction(
+                                    child: const Text('キャンセル'),
+                                    onPressed: () => Navigator.pop(context),
+                                  ),
+                                  const CupertinoDialogAction(
+                                    onPressed: openAppSettings,
+                                    child: Text('設定へ'),
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        }
+                      },
                     ),
                   ],
+                  cancelAction: CancelAction(
+                    title: const Text('キャンセル'),
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                  ),
+                );
+              },
+            ),
+            // 評価
+            SizedBox(height: 8.h),
+            Center(
+              child: RatingBar.builder(
+                initialRating: recipe.recipeGrade!,
+                minRating: 0.5,
+                allowHalfRating: true,
+                itemPadding: const EdgeInsets.symmetric(horizontal: 4).r,
+                itemBuilder: (context, _) => const Icon(
+                  Icons.star_rounded,
+                  color: Colors.amber,
                 ),
-              ),
-              SizedBox(height: 8.h),
-              IngredientTextFieldWidget(
-                recipe: recipe,
-              ),
-            ],
-          ),
-
-          // 手順
-          SizedBox(height: 8.h),
-          Column(
-            children: [
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  '手順',
-                  style: Theme.of(context).textTheme.subtitle2,
-                ),
-              ),
-              SizedBox(height: 8.h),
-              const ProcedureTextFieldWidget(),
-            ],
-          ),
-          // メモ
-          SizedBox(height: 8.h),
-          Column(
-            children: [
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  'メモ',
-                  style: Theme.of(context).textTheme.subtitle2,
-                ),
-              ),
-              SizedBox(height: 8.h),
-              TextField(
-                controller: TextEditingController(text: recipe.recipeMemo),
-                maxLength: 500,
-                maxLines: null,
-                onChanged: (value) {
-                  recipe.recipeMemo = value;
+                onRatingUpdate: (rating) {
+                  recipe.recipeGrade = rating;
                 },
               ),
-              SizedBox(height: 48.h),
-            ],
-          ),
-        ],
+            ),
+
+            // 材料
+            SizedBox(height: 8.h),
+            Column(
+              children: [
+                DefaultTextStyle(
+                  style: Theme.of(context).textTheme.subtitle2!,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Row(
+                        children: [
+                          const Text('材料'),
+                          SizedBox(width: 8.w),
+                          SizedBox(
+                            width: 24.w,
+                            child: TextField(
+                              decoration: InputDecoration(
+                                contentPadding: const EdgeInsets.only(
+                                  left: 2,
+                                  top: 4,
+                                  bottom: 4,
+                                ).r,
+                                isDense: true,
+                              ),
+                              controller: recipe.forHowManyPeople == null
+                                  ? null
+                                  : TextEditingController(
+                                      text: recipe.forHowManyPeople.toString(),
+                                    ),
+                              keyboardType: TextInputType.number,
+                              inputFormatters: <TextInputFormatter>[
+                                FilteringTextInputFormatter.digitsOnly,
+                                LengthLimitingTextInputFormatter(2)
+                              ],
+                              onChanged: (value) {
+                                if (int.tryParse(value) != null) {
+                                  recipe.forHowManyPeople = int.parse(value);
+                                }
+                              },
+                            ),
+                          ),
+                          const Text('人分'),
+                        ],
+                      ),
+                      TextButton.icon(
+                        onPressed: () {
+                          Navigator.push<MaterialPageRoute<dynamic>>(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  const IntroductionEditIngredientPage(),
+                            ),
+                          );
+                        },
+                        icon: Icon(
+                          Icons.help_outline_rounded,
+                          size: 20.sp,
+                          color: Theme.of(context).hintColor,
+                        ),
+                        label: Text(
+                          'ヘルプ',
+                          style: TextStyle(color: Theme.of(context).hintColor),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                SizedBox(height: 8.h),
+                IngredientTextFieldWidget(
+                  recipe: recipe,
+                ),
+              ],
+            ),
+
+            // 手順
+            SizedBox(height: 8.h),
+            Column(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '手順',
+                    style: Theme.of(context).textTheme.subtitle2,
+                  ),
+                ),
+                SizedBox(height: 8.h),
+                const ProcedureTextFieldWidget(),
+              ],
+            ),
+            // メモ
+            SizedBox(height: 8.h),
+            Column(
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    'メモ',
+                    style: Theme.of(context).textTheme.subtitle2,
+                  ),
+                ),
+                SizedBox(height: 8.h),
+                TextField(
+                  controller: TextEditingController(text: recipe.recipeMemo),
+                  maxLength: 500,
+                  maxLines: null,
+                  onChanged: (value) {
+                    recipe.recipeMemo = value;
+                  },
+                ),
+                SizedBox(height: 48.h),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
+++ b/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
@@ -203,6 +203,12 @@ class IngredientTextFieldWidget extends ConsumerWidget {
 
                               return TextButton(
                                 onPressed: () {
+                                  final currentScope = FocusScope.of(context);
+                                  if (!currentScope.hasPrimaryFocus &&
+                                      currentScope.hasFocus) {
+                                    FocusManager.instance.primaryFocus!
+                                        .unfocus();
+                                  }
                                   showCupertinoModalPopup<Container>(
                                     context: context,
                                     builder: (context) {

--- a/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
+++ b/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
@@ -25,14 +25,6 @@ class IngredientTextFieldWidget extends ConsumerWidget {
     final ingredientListNotifier =
         ref.watch(ingredientListNotifierProvider.notifier);
 
-    final validation = Validations();
-
-    final nameIsChanged = ref.watch(nameIsChangedProvider);
-    final nameIsChangedNotifier = ref.watch(nameIsChangedProvider.notifier);
-
-    final amountIsChanged = ref.watch(nameIsChangedProvider);
-    final amountIsChangedNotifier = ref.watch(nameIsChangedProvider.notifier);
-
     return Column(
       children: [
         Builder(
@@ -42,9 +34,9 @@ class IngredientTextFieldWidget extends ConsumerWidget {
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
               children: [
-                for (int index = 0; index < ingredientList.length; index++)
+                for (final ingredient in ingredientList)
                   Slidable(
-                    key: ValueKey(ingredientList[index].id),
+                    key: ValueKey(ingredient.id),
                     startActionPane: ActionPane(
                       extentRatio: 0.3,
                       motion: const ScrollMotion(),
@@ -56,7 +48,7 @@ class IngredientTextFieldWidget extends ConsumerWidget {
                           backgroundColor: Theme.of(context).dividerColor,
                           onPressed: (context) {
                             ingredientListNotifier.editSymbol(
-                              ingredientList[index].id,
+                              ingredient.id,
                               'a',
                             );
                           },
@@ -73,7 +65,7 @@ class IngredientTextFieldWidget extends ConsumerWidget {
                           backgroundColor: Theme.of(context).dividerColor,
                           onPressed: (context) {
                             ingredientListNotifier.editSymbol(
-                              ingredientList[index].id,
+                              ingredient.id,
                               'b',
                             );
                           },
@@ -92,205 +84,13 @@ class IngredientTextFieldWidget extends ConsumerWidget {
                           label: '削除',
                           backgroundColor: Theme.of(context).errorColor,
                           onPressed: (context) {
-                            ingredientListNotifier
-                                .remove(ingredientList[index].id);
+                            ingredientListNotifier.remove(ingredient.id);
                           },
                         )
                       ],
                     ),
-                    child: Row(
-                      children: [
-                        Container(
-                          alignment: Alignment.center,
-                          width: 24.w,
-                          child: (ingredientList[index].symbol == 'clover' ||
-                                  ingredientList[index].symbol == 'a')
-                              ? Text(
-                                  'a',
-                                  style: TextStyle(
-                                    fontSize: 16.sp,
-                                    color: Theme.of(context).primaryColor,
-                                  ),
-                                )
-                              : (ingredientList[index].symbol == 'diamond' ||
-                                      ingredientList[index].symbol == 'b')
-                                  ? Text(
-                                      'b',
-                                      style: TextStyle(
-                                        fontSize: 16.sp,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .secondary,
-                                      ),
-                                    )
-                                  : null,
-                        ),
-                        Expanded(
-                          flex: 6,
-                          child: TextField(
-                            textInputAction: TextInputAction.next,
-                            controller: nameIsChanged == false
-                                ? TextEditingController(
-                                    text: ingredientList[index].name,
-                                  )
-                                : null,
-                            maxLength: 20,
-                            decoration: const InputDecoration(
-                              hintText: '材料名',
-                              counterText: '',
-                            ),
-                            onChanged: (String value) {
-                              ingredientListNotifier.editName(
-                                ingredientList[index].id,
-                                value,
-                              );
-                              nameIsChangedNotifier.update((state) => true);
-                            },
-                          ),
-                        ),
-                        SizedBox(
-                          width: 8.w,
-                        ),
-                        Expanded(
-                          flex: 2,
-                          child: TextField(
-                            textInputAction: TextInputAction.done,
-                            controller: amountIsChanged == false
-                                ? TextEditingController(
-                                    text:
-                                        ingredientList[index].amount.toString(),
-                                  )
-                                : null,
-                            keyboardType: TextInputType.datetime,
-                            maxLength: 5,
-                            decoration: InputDecoration(
-                              hintText: '数量',
-                              counterText: '',
-                              errorText: validation.outputAmountErrorText(
-                                ingredientList[index].amount,
-                              ),
-                            ),
-                            onChanged: (value) {
-                              ingredientListNotifier.editAmount(
-                                ingredientList[index].id,
-                                value,
-                              );
-                              amountIsChangedNotifier.update((state) => true);
-                            },
-                          ),
-                        ),
-                        Expanded(
-                          flex: 2,
-                          child: ValueListenableBuilder(
-                            valueListenable:
-                                IngredientUnitBoxes.getIngredientUnit()
-                                    .listenable(),
-                            builder: (context, box, widget) {
-                              final ingredientTextFieldModel =
-                                  IngredientTextFieldModel();
-
-                              final ingredientUnitList =
-                                  ingredientTextFieldModel
-                                      .fetchIngredientUnitList();
-
-                              final unitNameForTextButton =
-                                  ingredientList[index].unit == null ||
-                                          ingredientList[index].unit == ''
-                                      ? '単位'
-                                      : ingredientList[index].unit!;
-
-                              var selectedUnitName = ingredientUnitList[0];
-
-                              return TextButton(
-                                onPressed: () {
-                                  final currentScope = FocusScope.of(context);
-                                  if (!currentScope.hasPrimaryFocus &&
-                                      currentScope.hasFocus) {
-                                    FocusManager.instance.primaryFocus!
-                                        .unfocus();
-                                  }
-                                  showCupertinoModalPopup<Container>(
-                                    context: context,
-                                    builder: (context) {
-                                      return Container(
-                                        height: 250.h,
-                                        color:
-                                            Theme.of(context).backgroundColor,
-                                        child: Column(
-                                          children: [
-                                            Row(
-                                              mainAxisAlignment:
-                                                  MainAxisAlignment
-                                                      .spaceBetween,
-                                              children: [
-                                                TextButton(
-                                                  child: const Text('戻る'),
-                                                  onPressed: () => Navigator.of(
-                                                    context,
-                                                  ).pop(),
-                                                ),
-                                                TextButton(
-                                                  child: const Text(
-                                                    '決定',
-                                                  ),
-                                                  onPressed: () {
-                                                    ingredientListNotifier
-                                                        .editUnit(
-                                                      ingredientList[index].id,
-                                                      selectedUnitName,
-                                                    );
-                                                    Navigator.of(
-                                                      context,
-                                                    ).pop();
-                                                  },
-                                                ),
-                                              ],
-                                            ),
-                                            const Divider(),
-                                            Expanded(
-                                              child: CupertinoPicker(
-                                                backgroundColor:
-                                                    Theme.of(context)
-                                                        .backgroundColor,
-                                                itemExtent: 30,
-                                                children: ingredientUnitList
-                                                    .map(
-                                                      (unitName) => Text(
-                                                        unitName,
-                                                        style: TextStyle(
-                                                          color: Theme.of(
-                                                            context,
-                                                          )
-                                                              .colorScheme
-                                                              .onBackground,
-                                                        ),
-                                                      ),
-                                                    )
-                                                    .toList(),
-                                                onSelectedItemChanged: (index) {
-                                                  selectedUnitName =
-                                                      ingredientUnitList[index];
-                                                },
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      );
-                                    },
-                                  );
-                                },
-                                child: Text(
-                                  unitNameForTextButton,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                        const Icon(
-                          Icons.drag_handle,
-                        ),
-                      ],
+                    child: _TextFieldRow(
+                      ingredient: ingredient,
                     ),
                   ),
               ],
@@ -351,6 +151,204 @@ class IngredientTextFieldWidget extends ConsumerWidget {
             ),
           ],
         )
+      ],
+    );
+  }
+}
+
+class _TextFieldRow extends ConsumerWidget {
+  const _TextFieldRow({Key? key, required this.ingredient}) : super(key: key);
+
+  final Ingredient ingredient;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final validation = Validations();
+
+    final ingredientListNotifier =
+        ref.watch(ingredientListNotifierProvider.notifier);
+
+    final nameIsChanged = ref.watch(nameIsChangedProvider);
+    final nameIsChangedNotifier = ref.watch(nameIsChangedProvider.notifier);
+
+    final amountIsChanged = ref.watch(nameIsChangedProvider);
+    final amountIsChangedNotifier = ref.watch(nameIsChangedProvider.notifier);
+
+    return Row(
+      children: [
+        Container(
+          alignment: Alignment.center,
+          width: 24.w,
+          child: (ingredient.symbol == 'clover' || ingredient.symbol == 'a')
+              ? Text(
+                  'a',
+                  style: TextStyle(
+                    fontSize: 16.sp,
+                    color: Theme.of(context).primaryColor,
+                  ),
+                )
+              : (ingredient.symbol == 'diamond' || ingredient.symbol == 'b')
+                  ? Text(
+                      'b',
+                      style: TextStyle(
+                        fontSize: 16.sp,
+                        color: Theme.of(context).colorScheme.secondary,
+                      ),
+                    )
+                  : null,
+        ),
+        Expanded(
+          flex: 6,
+          child: TextField(
+            textInputAction: TextInputAction.next,
+            controller: nameIsChanged == false
+                ? TextEditingController(
+                    text: ingredient.name,
+                  )
+                : null,
+            maxLength: 20,
+            decoration: const InputDecoration(
+              hintText: '材料名',
+              counterText: '',
+            ),
+            onChanged: (String value) {
+              ingredientListNotifier.editName(
+                ingredient.id,
+                value,
+              );
+              nameIsChangedNotifier.update((state) => true);
+            },
+          ),
+        ),
+        SizedBox(
+          width: 8.w,
+        ),
+        Expanded(
+          flex: 2,
+          child: TextField(
+            textInputAction: TextInputAction.done,
+            controller: amountIsChanged == false
+                ? TextEditingController(
+                    text: ingredient.amount.toString(),
+                  )
+                : null,
+            keyboardType: TextInputType.datetime,
+            maxLength: 5,
+            decoration: InputDecoration(
+              hintText: '数量',
+              counterText: '',
+              errorText: validation.outputAmountErrorText(
+                ingredient.amount,
+              ),
+            ),
+            onChanged: (value) {
+              ingredientListNotifier.editAmount(
+                ingredient.id,
+                value,
+              );
+              amountIsChangedNotifier.update((state) => true);
+            },
+          ),
+        ),
+        Expanded(
+          flex: 2,
+          child: ValueListenableBuilder(
+            valueListenable:
+                IngredientUnitBoxes.getIngredientUnit().listenable(),
+            builder: (context, box, widget) {
+              final ingredientTextFieldModel = IngredientTextFieldModel();
+
+              final ingredientUnitList =
+                  ingredientTextFieldModel.fetchIngredientUnitList();
+
+              final selectedUnit =
+                  ingredient.unit == null || ingredient.unit == ''
+                      ? '単位'
+                      : ingredient.unit!;
+
+              var selectedUnitName = ingredientUnitList[0];
+
+              return TextButton(
+                onPressed: () {
+                  // textFieldのfocusを外す処理
+                  final currentScope = FocusScope.of(context);
+                  if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
+                    FocusManager.instance.primaryFocus!.unfocus();
+                  }
+
+                  showCupertinoModalPopup<Container>(
+                    context: context,
+                    builder: (context) {
+                      return Container(
+                        height: 250.h,
+                        color: Theme.of(context).backgroundColor,
+                        child: Column(
+                          children: [
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                TextButton(
+                                  child: const Text('戻る'),
+                                  onPressed: () => Navigator.of(
+                                    context,
+                                  ).pop(),
+                                ),
+                                TextButton(
+                                  child: const Text(
+                                    '決定',
+                                  ),
+                                  onPressed: () {
+                                    ingredientListNotifier.editUnit(
+                                      ingredient.id,
+                                      selectedUnitName,
+                                    );
+                                    Navigator.of(
+                                      context,
+                                    ).pop();
+                                  },
+                                ),
+                              ],
+                            ),
+                            const Divider(),
+                            Expanded(
+                              child: CupertinoPicker(
+                                backgroundColor:
+                                    Theme.of(context).backgroundColor,
+                                itemExtent: 30,
+                                children: ingredientUnitList
+                                    .map(
+                                      (unitName) => Text(
+                                        unitName,
+                                        style: TextStyle(
+                                          color: Theme.of(
+                                            context,
+                                          ).colorScheme.onBackground,
+                                        ),
+                                      ),
+                                    )
+                                    .toList(),
+                                onSelectedItemChanged: (index) {
+                                  selectedUnitName = ingredientUnitList[index];
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  );
+                },
+                child: Text(
+                  selectedUnit,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              );
+            },
+          ),
+        ),
+        const Icon(
+          Icons.drag_handle,
+        ),
       ],
     );
   }

--- a/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
+++ b/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
@@ -42,7 +42,6 @@ class IngredientTextFieldWidget extends ConsumerWidget {
                       motion: const ScrollMotion(),
                       children: [
                         SlidableAction(
-                          // icon: FontAwesomeIcons.clover,
                           label: 'a',
                           foregroundColor: Theme.of(context).primaryColor,
                           backgroundColor: Theme.of(context).dividerColor,
@@ -58,7 +57,6 @@ class IngredientTextFieldWidget extends ConsumerWidget {
                             topRight: Radius.circular(10),
                             bottomRight: Radius.circular(10),
                           ),
-                          // icon: FontAwesomeIcons.diamond,
                           label: 'b',
                           foregroundColor:
                               Theme.of(context).colorScheme.secondary,
@@ -179,7 +177,7 @@ class _TextFieldRow extends ConsumerWidget {
         Container(
           alignment: Alignment.center,
           width: 24.w,
-          child: (ingredient.symbol == 'clover' || ingredient.symbol == 'a')
+          child: ingredient.symbol == 'a'
               ? Text(
                   'a',
                   style: TextStyle(
@@ -187,7 +185,7 @@ class _TextFieldRow extends ConsumerWidget {
                     color: Theme.of(context).primaryColor,
                   ),
                 )
-              : (ingredient.symbol == 'diamond' || ingredient.symbol == 'b')
+              : ingredient.symbol == 'b'
                   ? Text(
                       'b',
                       style: TextStyle(

--- a/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
+++ b/lib/components/widgets/reordable_text_field/ingredient_text_field/ingredient_text_field_widget.dart
@@ -128,6 +128,7 @@ class IngredientTextFieldWidget extends ConsumerWidget {
                         Expanded(
                           flex: 6,
                           child: TextField(
+                            textInputAction: TextInputAction.next,
                             controller: nameIsChanged == false
                                 ? TextEditingController(
                                     text: ingredientList[index].name,
@@ -153,6 +154,7 @@ class IngredientTextFieldWidget extends ConsumerWidget {
                         Expanded(
                           flex: 2,
                           child: TextField(
+                            textInputAction: TextInputAction.done,
                             controller: amountIsChanged == false
                                 ? TextEditingController(
                                     text:

--- a/lib/view/other/page_container/page_container_page.dart
+++ b/lib/view/other/page_container/page_container_page.dart
@@ -180,6 +180,7 @@ class PageContainerPage extends ConsumerWidget {
                   height: 8.h,
                 ),
                 TextField(
+                  textInputAction: TextInputAction.next,
                   autofocus: true,
                   maxLength: 20,
                   decoration: const InputDecoration(
@@ -190,6 +191,7 @@ class PageContainerPage extends ConsumerWidget {
                   },
                 ),
                 TextField(
+                  textInputAction: TextInputAction.done,
                   maxLength: 20,
                   decoration: const InputDecoration(
                     labelText: '詳細',


### PR DESCRIPTION
- 材料入力時、材料名入力後にキーボードで「次へ」を押下すると材料数量のtextFieldにフォーカスが移動するよう改修。
- otherCartItem入力時、アイテム名入力後にキーボードで「次へ」を押下すると詳細のtextFieldにフォーカスが移動するよう改修。
- edit_recipe_widgetにて、textFieldの外をタップするとフォーカスが外れるよう改修。